### PR TITLE
Update Kirby's core and panel modules paths for V2

### DIFF
--- a/kirby.config.json
+++ b/kirby.config.json
@@ -1,7 +1,7 @@
 {
   "modules": {
-    "core": "https://github.com/getkirby/kirby.git",
-    "panel": "https://github.com/getkirby/panel.git",
+    "core": "https://github.com/getkirby-v2/kirby.git",
+    "panel": "https://github.com/getkirby-v2/panel.git",
     "fields": {},
     "plugins": {},
     "tags": {},


### PR DESCRIPTION
Since Kirby 3 is out, Kirby Webpack (V2) needed to update the Kirby's core and panel modules paths with the correct version.