### PR TITLE
fixed outdated pattern

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,7 @@ const { appEnv } = require('./main.config')
 
 const config = {
   plugins: {
-    autoprefixer: { browsers: ['last 2 versions'] }
+    autoprefixer: { overrideBrowserslist: ['last 2 versions'] }
   }
 }
 


### PR DESCRIPTION
The way the autoprefixer plugin was implemented here is outdated.

```
warn
  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```

Therefore I renamed `browsers` into `overrideBrowserslist`.
Probably, the best way to do it would to move the plugin config into the package.json