### PR TITLE
Fixed package.json due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "resolve-url-loader": "^3.0.0",
     "style-loader": "^0.23.1",
     "tail": "^2.0.0",
-    "uglifyjs-webpack-plugin": "^2.0.1",
+    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.21.0",
     "webpack-dev-middleware": "^3.4.0",
     "webpack-hot-middleware": "^2.24.3",


### PR DESCRIPTION
The used `uglifyjs-webpack-plugin` had a vulnerability due to one of its dev dependencies (serialize-javascript) which was fixed in `2.1.0` (https://snyk.io/vuln/npm:serialize-javascript).